### PR TITLE
Enhances video uploads and AI tool access

### DIFF
--- a/packages/revo-web/src/components/Steps/Step2.jsx
+++ b/packages/revo-web/src/components/Steps/Step2.jsx
@@ -2446,6 +2446,7 @@ function Video({ setting }) {
   const { timeId, time = {}, setTimes, draft } = useContext(DraftContext)
   const { videos = [] } = time.setting || {}
   const { hasPermission } = usePermissions()
+  const { setToast } = useContext(ToastContext)
 
   // const [fileList, setfileList] = useState([])
   const [tempFile, settempFile] = useState(null)
@@ -2557,7 +2558,7 @@ function Video({ setting }) {
   }
   return (
     <>
-      <Row className="pt-3 pb-2 px-2" style={{ height: '10vh' }}>
+      <Row className="pt-3 pb-2 px-2" style={{ height: '12vh' }}>
         {hasPermission('editProject', draft.draft_user_role) && (
           <Col xs={2}>
             <Button variant="revo">
@@ -2570,6 +2571,12 @@ function Video({ setting }) {
                 &ensp;上傳影片檔案
               </FormLabel>
             </Button>
+            <p
+              className="text-center mt-1"
+              style={{ fontSize: '12px', color: '#666' }}
+            >
+              上傳影片大小限制為500mb。
+            </p>
             <Form.Control
               id="file"
               name="file"
@@ -2578,9 +2585,19 @@ function Video({ setting }) {
               accept="video/*"
               // value={fileList}
               onChange={(e) => {
-                setuploading(true)
-                settempFile(e.target.files[0])
-                e.target.value = null
+                const file = e.target.files?.[0]
+                if (file) {
+                  // Check if file size exceeds 500MB (500 * 1024 * 1024 bytes)
+                  const maxSize = 500 * 1024 * 1024
+                  if (file.size > maxSize) {
+                    e.target.value = '' // Clear the input
+                    setToast({ show: true, text: '上傳影片大小超過500mb。' })
+                  } else {
+                    setuploading(true)
+                    settempFile(e.target.files[0])
+                    e.target.value = null
+                  }
+                }
               }}
               style={{
                 visibility: 'hidden',

--- a/packages/revo-web/src/components/Steps/ToolBar.jsx
+++ b/packages/revo-web/src/components/Steps/ToolBar.jsx
@@ -96,22 +96,27 @@ function ToolBar({ setting }) {
     {
       label: 'AI影像辨識',
       name: 'step3',
-      click: {
-        name: 'step3',
-        value: '影像辨識',
-      },
-      // dropdowns: [
-      //   {
-      //     label: '影像辨識',
-      //     name: 'step3',
-      //     value: '影像辨識',
-      //   },
-      // {
-      //   label: '交通量檢核',
+      // click: {
       //   name: 'step3',
-      //   value: '交通量檢核',
+      //   value: '影像辨識',
       // },
-      // ],
+      dropdowns: [
+        {
+          label: '資料標記平台 (CVAT)',
+          name: 'step3',
+          value: '資料標記平台 (CVAT)',
+          onClick: (e) => {
+            e.preventDefault()
+            e.stopPropagation()
+            window.open('https://cvat.ai', '_blank', 'noopener,noreferrer')
+          },
+        },
+        {
+          label: 'AI影像辨識',
+          name: 'step3',
+          value: '影像辨識',
+        },
+      ],
     },
     {
       label: 'AI號控調校',
@@ -173,7 +178,11 @@ function ToolBar({ setting }) {
                     <li key={d.value}>
                       <a
                         className="dropdown-item"
-                        onClick={() => {
+                        onClick={(e) => {
+                          if (d.onClick) {
+                            d.onClick(e)
+                            return
+                          }
                           if (!timeId && d.name !== 'step1') {
                             setShow(true)
                           } else {


### PR DESCRIPTION
Implements client-side validation for video uploads, limiting file size to 500MB. Provides a clear message to the user about the size restriction and displays a toast notification if the uploaded file exceeds this limit, improving user experience by preventing failed uploads.

Restructures the 'AI影像辨識' menu into a dropdown. Introduces a new option to directly access the CVAT data labeling platform, streamlining the workflow for users needing to label data. The existing AI image recognition functionality is now accessible within this new dropdown.